### PR TITLE
Get Payment methods from user ID

### DIFF
--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -638,9 +638,6 @@ Content-Type: application/json
 ```
 
 Retrieves a list of all [Payments Method](#payment_methods) associated with a given user id.
-This route will work a bit differently if the authenticated user is an admin or a regular costumer.
-In case of a regular user/costumer, the user could execute this request only with his own `user id`. If he tries with another `user id` then the API will return an `403 error`.
-However, an `admin` user can search by any `user id`.
 
 Arguments | Type | Description
 -------- | ----- | -----

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -575,7 +575,7 @@ UNKNOWN | Delivery status is unknown
 QUEUED | Delivery is in queue
 
 
-## List All Orders for a User
+## List All Payment Methods for a User
 
 > Definition
 
@@ -595,47 +595,46 @@ Host: api.kvass.ai
 ``` http
 HTTP/1.1 200 OK
 Content-Type: application/json
-
-{
-   "_id":{"$oid":<payment-method-id>},
-   "_cls":"PaymentMethod.StripePaymentMethod",
-   "created":{"$date":1538058324877},
-   "modified":{"$date":1538058327405},
-   "deleted":false,
-   "active":true,
-   "user":{"$oid":"57ee9c72d76d431f85111432"},
-   "company":{"$oid":"591ee15db70e2a10acb65362"},
-   "name":"Stripe",
-   "method":"stripe",
-   "token":"tok_1DF0QiEeeXxFpLJtthyCQWVz",
-   "customer_id":"cus_DgNBPtNphW2W7r",
-   "card":{
-      "id":"card_1DF0QiEeeXxFpLJtg4AE1T5z",
-      "object":"card",
-      "address_city":null,
-      "address_country":null,
-      "address_line1":null,
-      "address_line1_check":null,
-      "address_line2":null,
-      "address_state":null,
-      "address_zip":null,
-      "address_zip_check":null,
-      "brand":"Visa",
-      "country":"US",
-      "cvc_check":"unchecked",
-      "dynamic_last4":null,
-      "exp_month":12,
-      "exp_year":2019,
-      "fingerprint":"npPw68vQg1usKUWb",
-      "funding":"credit",
-      "last4":"4242",
-      "metadata":{
-
-      },
-      "name":null,
-      "tokenization_method":null
-   }
-}
+[
+    {
+       "_id":{"$oid":<payment-method-id>},
+       "_cls":"PaymentMethod.StripePaymentMethod",
+       "created":{"$date":1538058324877},
+       "modified":{"$date":1538058327405},
+       "deleted":false,
+       "active":true,
+       "user":{"$oid":"57ee9c72d76d431f85111432"},
+       "company":{"$oid":"591ee15db70e2a10acb65362"},
+       "name":"Stripe",
+       "method":"stripe",
+       "token":"tok_1DF0QiEeeXxFpLJtthyCQWVz",
+       "customer_id":"cus_DgNBPtNphW2W7r",
+       "card":{
+          "id":"card_1DF0QiEeeXxFpLJtg4AE1T5z",
+          "object":"card",
+          "address_city":null,
+          "address_country":null,
+          "address_line1":null,
+          "address_line1_check":null,
+          "address_line2":null,
+          "address_state":null,
+          "address_zip":null,
+          "address_zip_check":null,
+          "brand":"Visa",
+          "country":"US",
+          "cvc_check":"unchecked",
+          "dynamic_last4":null,
+          "exp_month":12,
+          "exp_year":2019,
+          "fingerprint":"npPw68vQg1usKUWb",
+          "funding":"credit",
+          "last4":"4242",
+          "metadata":{},
+          "name":null,
+          "tokenization_method":null
+       }
+    }
+]
 ```
 
 Retrieves a list of all [Payments Method](#payment_methods) associated with a given user id.

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -574,3 +574,82 @@ DONE | Delivery is done
 UNKNOWN | Delivery status is unknown
 QUEUED | Delivery is in queue
 
+
+## List All Orders for a User
+
+> Definition
+
+```
+GET https://api.kvass.ai/users/<user-id>/payment_methods
+```
+
+> Example request:
+``` http
+GET /users/<user-id>/payment_methods HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer <jwt>
+X-Kvass-Api-Key: <kvass-api-key>
+Host: api.kvass.ai
+```
+
+``` http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+   "_id":{"$oid":<payment-method-id>},
+   "_cls":"PaymentMethod.StripePaymentMethod",
+   "created":{"$date":1538058324877},
+   "modified":{"$date":1538058327405},
+   "deleted":false,
+   "active":true,
+   "user":{"$oid":"57ee9c72d76d431f85111432"},
+   "company":{"$oid":"591ee15db70e2a10acb65362"},
+   "name":"Stripe",
+   "method":"stripe",
+   "token":"tok_1DF0QiEeeXxFpLJtthyCQWVz",
+   "customer_id":"cus_DgNBPtNphW2W7r",
+   "card":{
+      "id":"card_1DF0QiEeeXxFpLJtg4AE1T5z",
+      "object":"card",
+      "address_city":null,
+      "address_country":null,
+      "address_line1":null,
+      "address_line1_check":null,
+      "address_line2":null,
+      "address_state":null,
+      "address_zip":null,
+      "address_zip_check":null,
+      "brand":"Visa",
+      "country":"US",
+      "cvc_check":"unchecked",
+      "dynamic_last4":null,
+      "exp_month":12,
+      "exp_year":2019,
+      "fingerprint":"npPw68vQg1usKUWb",
+      "funding":"credit",
+      "last4":"4242",
+      "metadata":{
+
+      },
+      "name":null,
+      "tokenization_method":null
+   }
+}
+```
+
+Retrieves a list of all [Payments Method](#payment_methods) associated with a given user id.
+This route will work a bit differently if the authenticated user is an admin or a regular costumer.
+In case of a regular user/costumer, the user could execute this request only with his own `user id`. If he tries with another `user id` then the API will return an `403 error`.
+However, an `admin` user can search by any `user id`.
+
+Arguments | Type | Description
+-------- | ----- | -----
+**user_id** | `string` | ID of the user to retrieve Orders for.
+size | `number` | Number of items to retrieve.
+page | `number` | Which page to retrieve. _default is 10_
+sort | `string` | Field used for sorting results. _default is `created`_
+from_date | `number` | Start date, `timestamp` format. _default is current date minus 15 days_
+to_date | `number` | End date, `timestamp` format. _default current date plus 15 days_
+date_filter | `string` | Date field used to filter results. _default is `created`_
+include_deleted | `boolean` | If `true`, deleted users are also listed _default is `false`_


### PR DESCRIPTION
fix #98  

---

New route:
`GET /users/user_id/payment_methods`