### PR TITLE
fix code examples post payment-method

### DIFF
--- a/source/includes/_payment_methods.md
+++ b/source/includes/_payment_methods.md
@@ -122,7 +122,7 @@ X-Kvass-Api-Key: <kvass-api-key>
 Host: api.kvass.ai
 
 {
-  "method": "single_paypal",
+  "payment_method": "single_paypal",
   "payment_id": "<payment-id>",
   "payer_id": "<payer-id>"
 }
@@ -184,7 +184,7 @@ X-Kvass-Api-Key: <kvass-api-key>
 Host: api.kvass.ai
 
 {
-  "method": "future_paypal",
+  "payment_method": "future_paypal",
   "code": "<some-code>"
 }
 ```


### PR DESCRIPTION
fix #69 

---

`payment_method` instead of `method` in `POST /payment_methods`